### PR TITLE
Minor improvements

### DIFF
--- a/plotly_calplot/calplot.py
+++ b/plotly_calplot/calplot.py
@@ -9,12 +9,7 @@ def get_weeknumber_of_date(d):
     """
     Pandas week returns some strange values, this function fixes'em
     """
-    if d.month == 1 and d.week > 50:
-        return 0
-    elif d.month == 12 and d.week < 10:
-        return 53
-    else:
-        return d.week
+    return int(d.strftime('%W'))
 
 
 def year_calplot(

--- a/plotly_calplot/calplot.py
+++ b/plotly_calplot/calplot.py
@@ -8,7 +8,8 @@ from plotly.subplots import make_subplots
 
 def get_weeknumber_of_date(d):
     """
-    Pandas week returns some strange values, this function fixes'em
+    Pandas week returns ISO week number, this function
+    returns gregorian week date
     """
     return int(d.strftime('%W'))
 

--- a/plotly_calplot/calplot.py
+++ b/plotly_calplot/calplot.py
@@ -1,3 +1,4 @@
+from datetime import date
 import numpy as np
 import pandas as pd
 from pandas.core.frame import DataFrame
@@ -154,8 +155,8 @@ def year_calplot(
 
 
 def fill_empty_with_zeros(selected_year_data: DataFrame, x, dark_theme, year: int):
-    year_min_date = "01-01-" + str(year)
-    year_max_date = "31-12-" + str(year)
+    year_min_date = date(year=year, month=1, day=1)
+    year_max_date = date(year=year, month=12, day=31)
     df = pd.DataFrame({x: pd.date_range(year_min_date, year_max_date)})
     final_df = df.merge(selected_year_data, how="left")
     if not dark_theme:


### PR DESCRIPTION
### `get_weeknumber_of_date`

The `.week` function of pandas returns the [ISO week date](https://en.wikipedia.org/wiki/ISO_week_date#:~:text=An%20ISO%20week%2Dnumbering%20year,start%20on%20Wednesday%20the%201st.) instead of the desired gregorian calendar week number.

The gregorian week date can be obtained with `strftime`, and now `get_weeknumber_of_date` is more concise.

### `fill_empty_with_zeroes`

This function was giving me some UserWarnings with latest pandas version. It's because you are using a string and pandas recommends using datetime.

- [x] I've checked with `make pt_example` that the desired output is the same