### PR TITLE
Support custom hovertext in calplots

### DIFF
--- a/plotly_calplot/calplot.py
+++ b/plotly_calplot/calplot.py
@@ -1,5 +1,5 @@
 from datetime import date
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from pandas import DataFrame, Grouper, Series
 from plotly import graph_objects as go
@@ -67,6 +67,7 @@ def calplot(
     total_height: int = None,
     space_between_plots: float = 0.08,
     showscale: bool = False,
+    text: Optional[str] = None,
 ) -> go.Figure:
     """
     Yearly Calendar Heatmap
@@ -124,6 +125,9 @@ def calplot(
     showscale: bool = False
         if True, a color legend will be created.
         Thanks to @ghhar98!
+
+    text: Optional[str] = None
+        The name of the column in data to include in hovertext.
     """
     unique_years = data[x].dt.year.unique()
     unique_years_amount = len(unique_years)
@@ -163,6 +167,8 @@ def calplot(
             title=title,
             row=i,
             total_height=total_height,
+            text=None if text is None else selected_year_data[text].tolist(),
+            text_name=text,
         )
 
     fig = apply_general_colorscaling(data, y, fig)

--- a/plotly_calplot/date_extractors.py
+++ b/plotly_calplot/date_extractors.py
@@ -19,20 +19,10 @@ def get_date_coordinates(
     weekdays_in_year = [i.weekday() for i in data[x]]
 
     # sometimes the last week of the current year conflicts with next year's january
-    # pandas will give those weeks the number 52 or 53, but this is bad news for this plot
-    # therefore we need a correction, for a more in-depth explanation check
+    # pandas uses ISO weeks, which will give those weeks the number 52 or 53, but this
+    # is bad news for this plot therefore we need a correction to use Gregorian weeks,
+    # for a more in-depth explanation check
     # https://stackoverflow.com/questions/44372048/python-pandas-timestamp-week-returns-52-for-first-day-of-year
-
-    weeknumber_of_dates = (
-        data[x].apply(lambda x: get_weeknumber_of_date(x)).values.tolist()
-    )
+    weeknumber_of_dates = data[x].dt.strftime("%W").astype(int).tolist()
 
     return month_positions, weekdays_in_year, weeknumber_of_dates
-
-
-def get_weeknumber_of_date(d: pd.Timestamp) -> int:
-    """
-    Pandas week returns ISO week number, this function
-    returns gregorian week date
-    """
-    return int(d.strftime("%W"))

--- a/plotly_calplot/date_extractors.py
+++ b/plotly_calplot/date_extractors.py
@@ -13,7 +13,7 @@ def get_date_coordinates(
 ) -> Tuple[Any, List[float], List[int]]:
     month_days = []
     for m in data[x].dt.month.unique():
-        month_days.append(data.loc[data[x].dt.month == m].max()[x].day)
+        month_days.append(data.loc[data[x].dt.month == m, x].max().day)
 
     month_positions = (np.cumsum(month_days) - 15) / 7
     weekdays_in_year = [i.weekday() for i in data[x]]

--- a/plotly_calplot/raw_heatmap.py
+++ b/plotly_calplot/raw_heatmap.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 import numpy as np
 import pandas as pd
@@ -15,7 +15,15 @@ def create_heatmap_without_formatting(
     year: int,
     colorscale: str,
     name: str,
+    text: Optional[List[str]] = None,
+    text_name: Optional[str] = None,
 ) -> List[go.Figure]:
+    hovertemplate_extra = ""
+    if text is not None:
+        hovertemplate_extra = " <br>"
+        if text_name is not None:
+            hovertemplate_extra += f"{text_name}="
+        hovertemplate_extra += "%{text}"
     raw_heatmap = [
         go.Heatmap(
             x=weeknumber_of_dates,
@@ -25,7 +33,11 @@ def create_heatmap_without_formatting(
             ygap=gap,  # and this is used to make the grid-like apperance
             showscale=False,
             colorscale=colorscale,  # user can setup their colorscale
-            hovertemplate="%{customdata[0]} <br>%{customdata[1]}=%{z} <br>Week=%{x}",
+            text=text,
+            hovertemplate=(
+                "%{customdata[0]} <br>%{customdata[1]}=%{z} <br>Week=%{x}"
+                + hovertemplate_extra
+            ),
             customdata=np.stack((data[x].astype(str), [name] * data.shape[0]), axis=-1),
             name=str(year),
         )

--- a/plotly_calplot/raw_heatmap.py
+++ b/plotly_calplot/raw_heatmap.py
@@ -35,7 +35,7 @@ def create_heatmap_without_formatting(
             colorscale=colorscale,  # user can setup their colorscale
             text=text,
             hovertemplate=(
-                "%{customdata[0]} <br>%{customdata[1]}=%{z} <br>Week=%{x}"
+                "%{customdata[0]} <br>Week=%{x} <br>%{customdata[1]}=%{z}"
                 + hovertemplate_extra
             ),
             customdata=np.stack((data[x].astype(str), [name] * data.shape[0]), axis=-1),

--- a/plotly_calplot/single_year_calplot.py
+++ b/plotly_calplot/single_year_calplot.py
@@ -1,3 +1,5 @@
+from typing import List, Optional
+
 from pandas.core.frame import DataFrame
 from plotly import graph_objects as go
 
@@ -26,6 +28,8 @@ def year_calplot(
     title: str = "",
     month_lines: bool = True,
     total_height: int = None,
+    text: Optional[List[str]] = None,
+    text_name: Optional[str] = None,
 ) -> go.Figure:
     """
     Each year is subplotted separately and added to the main plot
@@ -38,7 +42,17 @@ def year_calplot(
 
     # the calendar is actually a heatmap :)
     cplt = create_heatmap_without_formatting(
-        data, x, y, weeknumber_of_dates, weekdays_in_year, gap, year, colorscale, name
+        data,
+        x,
+        y,
+        weeknumber_of_dates,
+        weekdays_in_year,
+        gap,
+        year,
+        colorscale,
+        name,
+        text=text,
+        text_name=text_name,
     )
 
     if month_lines:

--- a/tests/test_date_extractors.py
+++ b/tests/test_date_extractors.py
@@ -4,11 +4,7 @@ from unittest import TestCase
 import numpy as np
 import pandas as pd
 
-from plotly_calplot.date_extractors import (
-    get_date_coordinates,
-    get_month_names,
-    get_weeknumber_of_date,
-)
+from plotly_calplot.date_extractors import get_date_coordinates, get_month_names
 
 
 class TestUtils(TestCase):
@@ -49,10 +45,3 @@ class TestUtils(TestCase):
         self.assertEqual(len(weeknumber_of_dates), self.sample_dataframe.shape[0])
         self.assertTrue(max(weeknumber_of_dates) <= 53)
         self.assertTrue(min(weeknumber_of_dates) >= 0)
-
-    def test_should_get_weeknumber_of_date(self) -> None:
-        tested_date = datetime(2020, 12, 31)
-        result = get_weeknumber_of_date(tested_date)
-
-        self.assertEqual(result, 52)
-        self.assertEqual(type(result), int)


### PR DESCRIPTION
Adds support for custom text in the calplot hover tooltip.

<img width="120" alt="Screen Shot 2022-09-03 at 23 25 48" src="https://user-images.githubusercontent.com/2555532/188288127-ca31604c-4c36-42f2-a7bf-0446452ea4eb.png">