### PR TITLE
Update CI poetry installation

### DIFF
--- a/.github/workflows/plotly_ci.yaml
+++ b/.github/workflows/plotly_ci.yaml
@@ -21,9 +21,9 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.8
-  
+
     - name: Install Poetry
-      uses: dschep/install-poetry-action@v1.2
+      uses: snok/install-poetry@v1
 
     - name: Cache Poetry virtualenv
       uses: actions/cache@v1
@@ -36,7 +36,7 @@ jobs:
 
     - name: Install dependencies
       run: poetry install
-      
+
     - name: Run formatter
       run: make lint
 


### PR DESCRIPTION
CI failed in https://github.com/brunorosilva/plotly-calplot/pull/13 installing poetry. The GH Action that used to be used (`dschep/install-poetry-action`) has been deprecated and points to `snok/install-poetry` now - this updates CI to use that (which 🤞 will fix it).
